### PR TITLE
Feat/check command

### DIFF
--- a/.github/workflows/test-on-main.yml
+++ b/.github/workflows/test-on-main.yml
@@ -17,6 +17,12 @@ jobs:
       fail-fast: true
 
     steps:
+      - name: Skip duplicate actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-gold.svg)](LICENSE) ![Release](https://img.shields.io/badge/release-0.2.1-forestgreen) [![PyPI version](https://badge.fury.io/py/batch-tamarin.svg)](https://badge.fury.io/py/batch-tamarin)
 
-A Python wrapper for Tamarin Prover that enables batch execution of protocol verification tasks with JSON configuration files and comprehensive reporting.
+A Python wrapper for Tamarin Prover that enables batch execution of protocol verification tasks with JSON configuration files, comprehensive reporting, and validation tools.
 
 ![WrapperLogo](assets/logo.png)
 
@@ -13,7 +13,9 @@ A Python wrapper for Tamarin Prover that enables batch execution of protocol ver
 -   **Resource Management**: Intelligent CPU and memory allocation for parallel task execution
 -   **Progress Tracking**: Real-time progress updates with Rich-formatted output
 -   **Output Processing**: Reformat the different Tamarin output to give a detailed summary of execution
--   **CLI Interface**: Easy-to-use command-line interface with comprehensive options
+-   **CLI Interface**: Easy-to-use command-line interface with `run` and `check` commands
+-   **Configuration Validation**: Validate JSON recipes and preview tasks before execution
+-   **Wellformedness Checking**: Check theory files for syntax errors and warnings
 
 ## Table of Contents
 
@@ -73,14 +75,20 @@ batch-tamarin --version
 # Show help
 batch-tamarin --help
 
-# Run with configuration file
-batch-tamarin recipe.json
+# Run tasks with configuration file
+batch-tamarin run recipe.json
 
 # Run with debug output
-batch-tamarin recipe.json --debug
+batch-tamarin run recipe.json --debug
 
-# Run with Tamarin binary validation
-batch-tamarin recipe.json --revalidate
+# Check configuration and preview tasks
+batch-tamarin check recipe.json
+
+# Check with detailed wellformedness report
+batch-tamarin check recipe.json --report
+
+# Check with debug output
+batch-tamarin check recipe.json --debug
 ```
 
 ### Configuration Example
@@ -138,6 +146,34 @@ Create a JSON configuration file based on the WPA2 example:
 ```
 
 Read the configuration guide to understand how to write a JSON recipe : [`JSON Guide`](RECIPE_GUIDE.md)
+
+### Check Command
+
+The `check` command allows you to validate your configuration and preview the tasks that would be executed without actually running them:
+
+```bash
+# Basic configuration check
+batch-tamarin check recipe.json
+
+# Check with detailed wellformedness report
+batch-tamarin check recipe.json --report
+```
+
+**What the check command does:**
+- Validates JSON recipe structure and syntax
+- Checks file paths and accessibility
+- Tests Tamarin binary integrity
+- Previews executable tasks that would be run
+- Validates theory files for wellformedness issues
+- Generates detailed reports when using `--report` flag
+
+**Output includes:**
+- Total tasks that would be executed
+- Task breakdown by Tamarin version
+- Resource allocation summary
+- Tamarin version integrity test results
+- Any validation errors or warnings found
+- Wellformedness check reports (with `--report` flag)
 
 ### Output
 
@@ -280,7 +316,7 @@ Since the package uses proper Python packaging structure, you cannot run `python
 
 ```bash
 # Method 1 (Recommended): Use the CLI command (after pip install -e .)
-batch-tamarin
+batch-tamarin --help
 
 # Method 2: Test built package (Useful before publishing)
 python -m build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Batch Tamarin (`batch-tamarin`) : Tamarin Python Wrapper
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-gold.svg)](LICENSE) ![Release](https://img.shields.io/badge/release-0.2.0-forestgreen) [![PyPI version](https://badge.fury.io/py/batch-tamarin.svg)](https://badge.fury.io/py/batch-tamarin)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-gold.svg)](LICENSE) ![Release](https://img.shields.io/badge/release-0.2.1-forestgreen) [![PyPI version](https://badge.fury.io/py/batch-tamarin.svg)](https://badge.fury.io/py/batch-tamarin)
 
 A Python wrapper for Tamarin Prover that enables batch execution of protocol verification tasks with JSON configuration files and comprehensive reporting.
 

--- a/examples/errors/errors.json
+++ b/examples/errors/errors.json
@@ -3,7 +3,7 @@
 		"global_max_cores": "max",
 		"global_max_memory": "max",
 		"default_timeout": 80,
-		"output_directory": "./errors-results"
+		"output_directory": "errors-results"
 	},
 	"tamarin_versions": {
 		"default": {

--- a/examples/errors/errors.json
+++ b/examples/errors/errors.json
@@ -1,0 +1,20 @@
+{
+	"config": {
+		"global_max_cores": "max",
+		"global_max_memory": "max",
+		"default_timeout": 80,
+		"output_directory": "./errors-results"
+	},
+	"tamarin_versions": {
+		"default": {
+			"path": "tamarin-prover"
+		}
+	},
+	"tasks": {
+        "FullErrors": {
+            "theory_file": "examples/errors/protocols/errors.spthy",
+            "tamarin_versions": ["default"],
+            "output_file_prefix": "FullErrors"
+        }
+    }
+}

--- a/examples/errors/protocols/errors.spthy
+++ b/examples/errors/protocols/errors.spthy
@@ -1,0 +1,63 @@
+/* This file is made to trigger almost all error cases in Tamarin */
+
+theory Error
+begin
+
+builtins: symmetric-encryption, diffie-hellman
+
+/* No Out or K facts should appear in the premises of protocol rules and
+   no Fr, In, or K facts should appear in the conclusions. */
+rule error_1:
+    [ Fr(~i), Out(~i), K(~i) ]
+  --[ Test_1(~i) ]->
+    [ Fr(~j), In(a), Test(~i) ]
+
+/* Facts must have the same arity everywhere, i.e., in all rules, lemmas, and
+   restrictions. */
+rule error_2:
+    [ Test(i, j) ]
+  --[ Test_2(i, j)  ]->
+    [  ]
+
+/* Fr facts must be used with a variable of type message or type fresh. */
+rule error_4:
+    [ Fr(a) ]
+  --[  ]->
+    [  ]
+
+/* All variables in the conclusions of a rule must appear in the premises, or
+   be public variables. */
+rule error_5:
+    [  ]
+  --[  ]->
+    [ Out(a) ]
+
+/* The premises of a rule must not contain reducible function symbols such as
+   decryption, XOR, etc. */
+rule error_6:
+    [ Test(sdec(m,k)), In(m) ]
+  --[  ]->
+    [  ]
+
+/* The conclusions of a rule must not contain multiplication. */
+rule error_7:
+    [ In(<a, b>) ]
+  --[  ]->
+    [ Out(a * bs) ]
+
+/* Variable with mismatching sorts or capitalization + unbound variables. */
+rule error_8:
+    [ TesT(a) ]
+  --[  ]->
+    [ TesT(b) ]
+
+/* All action facts used in lemmas or restrictions should appear somewhere in
+   the rules. */
+lemma error_lemma_1: exists-trace
+    " Ex #i. Error()@i "
+
+/* All lemmas must be guarded formulas. */
+lemma error_lemma_2: exists-trace
+    " Ex a #i. Test_1(a)@i ==> Ex #j. Test_2(a, b)@j "
+
+end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "batch-tamarin"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python wrapper for Tamarin Prover with JSON configuration"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/batch_tamarin/__init__.py
+++ b/src/batch_tamarin/__init__.py
@@ -1,6 +1,6 @@
 """Tamarin Python Wrapper - Run Tamarin Prover models with JSON recipes."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Luca Mandrelli <luca.mandrelli@icloud.com>"
 
 from .main import app

--- a/src/batch_tamarin/main.py
+++ b/src/batch_tamarin/main.py
@@ -47,6 +47,28 @@ def main_callback(
         raise typer.Exit()
 
 
+async def process_config_file(config_path: Path) -> None:
+    """Process configuration file and execute tasks."""
+    try:
+        # Load recipe from configuration file
+        config_manager = ConfigManager()
+        recipe = await config_manager.load_json_recipe(config_path)
+
+        # Initialize TaskRunner - this validates and potentially corrects resource limits
+        # The ResourceManager within TaskRunner may update recipe.config with corrected values
+        runner = TaskRunner(recipe)
+
+        # Convert recipe to executable tasks using the recipe
+        executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
+
+        # Execute all tasks using runner
+        await runner.execute_all_tasks(executable_tasks)
+
+    except Exception as e:
+        notification_manager.error(f"Execution failed: {e}")
+        raise typer.Exit(1)
+
+
 @app.command()
 def run(
     config_file: str = typer.Argument(..., help="JSON recipe file to execute"),
@@ -72,7 +94,7 @@ def run(
         raise typer.Exit(1)
 
 
-async def check_command(config_path: Path, with_tamarin: bool = False) -> None:
+async def check_command(config_path: Path, report: bool) -> None:
     """Check configuration and show executable tasks that would be run."""
     try:
         # Load recipe from configuration file
@@ -80,20 +102,16 @@ async def check_command(config_path: Path, with_tamarin: bool = False) -> None:
         recipe = await config_manager.load_json_recipe(config_path)
 
         # Check tamarin integrity
-        notification_manager.phase_separator("Tamarin Integrity Testing")
         await check_tamarin_integrity(recipe.tamarin_versions)
 
         # Initialize output manager (bypass directory creation)
-        output_manager.initialize(config_path, bypass=True)
+        output_manager.initialize(Path(recipe.config.output_directory), bypass=True)
 
         # Convert recipe to executable tasks
         executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
 
-        # Collect tamarin validation errors if --with-tamarin is specified
-        tamarin_errors = None
-        if with_tamarin:
-            notification_manager.phase_separator("Tamarin Validation Testing")
-            tamarin_errors = await validate_with_tamarin(executable_tasks)
+        # Collect tamarin validation errors
+        tamarin_errors = await validate_with_tamarin(executable_tasks, report)
 
         # Display the check report
         notification_manager.check_report(recipe, executable_tasks, tamarin_errors)
@@ -106,47 +124,29 @@ async def check_command(config_path: Path, with_tamarin: bool = False) -> None:
 @app.command()
 def check(
     config_file: str = typer.Argument(..., help="JSON recipe file to check"),
-    with_tamarin: bool = typer.Option(
+    report: bool = typer.Option(
         False,
-        "--with-tamarin",
-        help="Test tamarin executables with theory files to check for warnings/errors",
+        "--report",
+        "-r",
+        help="Give Tamarin output report",
     ),
+    debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug output"),
 ) -> None:
     """
     Check configuration and show executable tasks that would be run.
-
-    This command validates the configuration file, checks tamarin integrity,
-    and displays a comprehensive report of all tasks that would be executed.
     """
+    # Set debug mode if enabled
+    if debug:
+        notification_manager.set_debug(True)
+        notification_manager.debug("[NotificationUtil] DEBUG Enabled")
+
     config_path = Path(config_file)
     try:
-        asyncio.run(check_command(config_path, with_tamarin))
+        asyncio.run(check_command(config_path, report))
     except typer.Exit:
         raise
     except Exception as e:
         notification_manager.error(f"Failed to check configuration: {e}")
-        raise typer.Exit(1)
-
-
-async def process_config_file(config_path: Path) -> None:
-    """Process configuration file and execute tasks."""
-    try:
-        # Load recipe from configuration file
-        config_manager = ConfigManager()
-        recipe = await config_manager.load_json_recipe(config_path)
-
-        # Initialize TaskRunner - this validates and potentially corrects resource limits
-        # The ResourceManager within TaskRunner may update recipe.config with corrected values
-        runner = TaskRunner(recipe)
-
-        # Convert recipe to executable tasks using the recipe
-        executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
-
-        # Execute all tasks using runner
-        await runner.execute_all_tasks(executable_tasks)
-
-    except Exception as e:
-        notification_manager.error(f"Execution failed: {e}")
         raise typer.Exit(1)
 
 

--- a/src/batch_tamarin/main.py
+++ b/src/batch_tamarin/main.py
@@ -1,67 +1,29 @@
 import asyncio
 from pathlib import Path
-from typing import Optional
 
 import typer
 
 from . import __author__, __version__
 from .modules.config_manager import ConfigManager
+from .modules.output_manager import output_manager
+from .modules.tamarin_test_cmd import check_tamarin_integrity
 from .runner import TaskRunner
+from .utils.model_checking import validate_with_tamarin
 from .utils.notifications import notification_manager
 
 app = typer.Typer(help="batch-tamarin")
 
 
-async def process_config_file(config_path: Path, revalidate: bool = False) -> None:
-    """Process configuration file and execute tasks."""
-    try:
-        # Load recipe from configuration file
-        config_manager = ConfigManager()
-        recipe = await config_manager.load_json_recipe(config_path, revalidate)
-
-        # Initialize TaskRunner - this validates and potentially corrects resource limits
-        # The ResourceManager within TaskRunner may update recipe.config with corrected values
-        runner = TaskRunner(recipe)
-
-        # Convert recipe to executable tasks using the recipe
-        executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
-
-        # Execute all tasks using runner
-        await runner.execute_all_tasks(executable_tasks)
-
-    except Exception as e:
-        notification_manager.error(f"Execution failed: {e}")
-        raise typer.Exit(1)
-
-
-def main(
-    config_file: Optional[str] = typer.Argument(
-        None, help="JSON recipe file to execute"
-    ),
+@app.callback(invoke_without_command=True)
+def main_callback(
+    ctx: typer.Context,
     version: bool = typer.Option(
-        False, "--version", "-v", help="Show batch-tamarin version."
+        False, "--version", "-v", help="Show version information"
     ),
-    revalidate: bool = typer.Option(
-        False,
-        "--revalidate",
-        "-r",
-        help="Check tamarin binaries integrity at startup.",
-    ),
-    debug: bool = typer.Option(
-        False,
-        "--debug",
-        "-d",
-        help="Enable debug output.",
-    ),
-) -> None:
+):
     """
-    Entry point for the batch-tamarin application.
+    Batch Tamarin - Protocol verification automation tool.
     """
-    # Set debug mode if enabled
-    if debug:
-        notification_manager.set_debug(True)
-        notification_manager.debug("[NotificationUtil] DEBUG Enabled")
-
     if version:
         print(
             r"""
@@ -80,17 +42,28 @@ def main(
         )
         return
 
-    # Check if config file is provided when not showing version
-    if not config_file:
-        print("Error: Missing argument 'CONFIG_FILE'.")
-        print("Usage: batch-tamarin [OPTIONS] CONFIG_FILE")
-        print("Try 'batch-tamarin --help' for help.")
-        raise typer.Exit(1)
+    if ctx.invoked_subcommand is None:
+        print(ctx.get_help())
+        raise typer.Exit()
+
+
+@app.command()
+def run(
+    config_file: str = typer.Argument(..., help="JSON recipe file to execute"),
+    debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug output"),
+) -> None:
+    """
+    Execute tasks from the specified configuration file.
+    """
+    # Set debug mode if enabled
+    if debug:
+        notification_manager.set_debug(True)
+        notification_manager.debug("[NotificationUtil] DEBUG Enabled")
 
     # Execute config file tasks
     config_path = Path(config_file)
     try:
-        asyncio.run(process_config_file(config_path, revalidate))
+        asyncio.run(process_config_file(config_path))
     except typer.Exit:
         # Re-raise typer.Exit to maintain proper exit codes
         raise
@@ -99,10 +72,88 @@ def main(
         raise typer.Exit(1)
 
 
+async def check_command(config_path: Path, with_tamarin: bool = False) -> None:
+    """Check configuration and show executable tasks that would be run."""
+    try:
+        # Load recipe from configuration file
+        config_manager = ConfigManager()
+        recipe = await config_manager.load_json_recipe(config_path)
+
+        # Check tamarin integrity
+        notification_manager.phase_separator("Tamarin Integrity Testing")
+        await check_tamarin_integrity(recipe.tamarin_versions)
+
+        # Initialize output manager (bypass directory creation)
+        output_manager.initialize(config_path, bypass=True)
+
+        # Convert recipe to executable tasks
+        executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
+
+        # Collect tamarin validation errors if --with-tamarin is specified
+        tamarin_errors = None
+        if with_tamarin:
+            notification_manager.phase_separator("Tamarin Validation Testing")
+            tamarin_errors = await validate_with_tamarin(executable_tasks)
+
+        # Display the check report
+        notification_manager.check_report(recipe, executable_tasks, tamarin_errors)
+
+    except Exception as e:
+        notification_manager.error(f"Check failed: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def check(
+    config_file: str = typer.Argument(..., help="JSON recipe file to check"),
+    with_tamarin: bool = typer.Option(
+        False,
+        "--with-tamarin",
+        help="Test tamarin executables with theory files to check for warnings/errors",
+    ),
+) -> None:
+    """
+    Check configuration and show executable tasks that would be run.
+
+    This command validates the configuration file, checks tamarin integrity,
+    and displays a comprehensive report of all tasks that would be executed.
+    """
+    config_path = Path(config_file)
+    try:
+        asyncio.run(check_command(config_path, with_tamarin))
+    except typer.Exit:
+        raise
+    except Exception as e:
+        notification_manager.error(f"Failed to check configuration: {e}")
+        raise typer.Exit(1)
+
+
+async def process_config_file(config_path: Path) -> None:
+    """Process configuration file and execute tasks."""
+    try:
+        # Load recipe from configuration file
+        config_manager = ConfigManager()
+        recipe = await config_manager.load_json_recipe(config_path)
+
+        # Initialize TaskRunner - this validates and potentially corrects resource limits
+        # The ResourceManager within TaskRunner may update recipe.config with corrected values
+        runner = TaskRunner(recipe)
+
+        # Convert recipe to executable tasks using the recipe
+        executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
+
+        # Execute all tasks using runner
+        await runner.execute_all_tasks(executable_tasks)
+
+    except Exception as e:
+        notification_manager.error(f"Execution failed: {e}")
+        raise typer.Exit(1)
+
+
 def cli():
     """Entry point for the CLI when installed via pip."""
-    typer.run(main)
+    app()
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    app()

--- a/src/batch_tamarin/modules/config_manager.py
+++ b/src/batch_tamarin/modules/config_manager.py
@@ -451,7 +451,7 @@ class ConfigManager:
                     tamarin_version_name=tamarin_version,
                     tamarin_executable=tamarin_executable,
                     theory_file=theory_file,
-                    output_file=models_dir / f"{unique_task_id}.json",
+                    output_file=models_dir / f"{unique_task_id}.spthy",
                     lemma=lemma_config.lemma_name,
                     tamarin_options=lemma_config.tamarin_options,
                     preprocess_flags=lemma_config.preprocess_flags,

--- a/src/batch_tamarin/modules/config_manager.py
+++ b/src/batch_tamarin/modules/config_manager.py
@@ -16,7 +16,6 @@ from ..model.tamarin_recipe import (
 from ..utils.notifications import notification_manager
 from .lemma_parser import LemmaParser, LemmaParsingError
 from .output_manager import output_manager
-from .tamarin_test_cmd import check_tamarin_integrity
 
 
 @dataclass
@@ -42,15 +41,12 @@ class ConfigManager:
     task_id_counter: Dict[str, int] = {}
 
     @staticmethod
-    async def load_json_recipe(
-        config_path: Path, revalidate: bool = False
-    ) -> TamarinRecipe:
+    async def load_json_recipe(config_path: Path) -> TamarinRecipe:
         """
         Load TamarinRecipe configuration from a JSON file.
 
         Args:
             config_path: Path to the configuration file
-            revalidate: If True, re-validate all tamarin versions after loading
 
         Returns:
             Configured TamarinRecipe instance
@@ -74,11 +70,6 @@ class ConfigManager:
                 json_data = f.read()
 
             recipe = TamarinRecipe.model_validate_json(json_data)
-
-            # Handle revalidation if requested
-            if revalidate:
-                notification_manager.phase_separator("Tamarin Integrity Testing")
-                await check_tamarin_integrity(recipe.tamarin_versions)
 
             notification_manager.phase_separator("Configuration")
             notification_manager.success(

--- a/src/batch_tamarin/modules/config_manager.py
+++ b/src/batch_tamarin/modules/config_manager.py
@@ -14,6 +14,7 @@ from ..model.tamarin_recipe import (
     Task,
 )
 from ..utils.notifications import notification_manager
+from ..utils.system_resources import resolve_executable_path
 from .lemma_parser import LemmaParser, LemmaParsingError
 from .output_manager import output_manager
 
@@ -489,16 +490,17 @@ class ConfigManager:
         version_name: str, tamarin_version: TamarinVersion, recipe: TamarinRecipe
     ) -> Path:
         """Validate that tamarin executable exists and is a file."""
-        tamarin_executable = Path(tamarin_version.path)
-        if not tamarin_executable.exists():
+        try:
+            tamarin_executable = resolve_executable_path(tamarin_version.path)
+            return tamarin_executable
+        except FileNotFoundError as e:
             raise ConfigError(
-                f"[ConfigManager] Tamarin executable not found for alias '{version_name}': {tamarin_executable}"
-            )
-        if not tamarin_executable.is_file():
+                f"[ConfigManager] Tamarin executable not found for alias '{version_name}': {e}"
+            ) from e
+        except ValueError as e:
             raise ConfigError(
-                f"[ConfigManager] Tamarin executable path is not a file for alias '{version_name}': {tamarin_executable}"
-            )
-        return tamarin_executable
+                f"[ConfigManager] Tamarin executable path is not a file for alias '{version_name}': {e}"
+            ) from e
 
     @staticmethod
     def _handle_validation_error(

--- a/src/batch_tamarin/modules/output_manager.py
+++ b/src/batch_tamarin/modules/output_manager.py
@@ -109,7 +109,7 @@ class OutputManager:
         self.models_dir: Path = Path(".")  # Will be set during initialize()
         self._is_setup = False
 
-    def initialize(self, output_dir: Path) -> None:
+    def initialize(self, output_dir: Path, bypass: bool = False) -> None:
         """
         Initialize the output manager with output directory.
 
@@ -117,6 +117,7 @@ class OutputManager:
 
         Args:
             output_dir: Base output directory path
+            bypass: If True, bypass directory creation (optional, for check command)
         """
         if self._is_setup:
             # Already initialized
@@ -127,6 +128,9 @@ class OutputManager:
         self.failed_dir = self.output_dir / "failed"
         self.models_dir = self.output_dir / "proofs"
         self._is_setup = True
+
+        if bypass:
+            return
 
         # Handle existing directory
         self._handle_existing_directory()

--- a/src/batch_tamarin/modules/tamarin_test_cmd.py
+++ b/src/batch_tamarin/modules/tamarin_test_cmd.py
@@ -82,8 +82,8 @@ async def launch_tamarin_test(path: Path) -> bool:
                 f"[TamarinTest] Test command failed, tamarin {path} might not work as intended."
             )
             if stdout:
-                notification_manager.debug(
-                    f"[#ff0000][ERROR][/#ff0000][TamarinTest] Error output:\n {chr(10).join(stdout.strip().splitlines()[-4:])}"
+                notification_manager.error(
+                    f"[TamarinTest] Error output:\n {chr(10).join(stdout.strip().splitlines()[-4:])}"
                 )
             return False
 
@@ -164,14 +164,6 @@ async def check_tamarin_integrity(tamarin_versions: Dict[str, TamarinVersion]) -
                 notification_manager.warning(
                     f"Tamarin integrity test failed for alias '{version_name}'"
                 )
-                should_continue = notification_manager.prompt_user(
-                    "Would you like to continue anyway ?", default=True
-                )
-
-                if not should_continue:
-                    notification_manager.critical(
-                        f"[TamarinTest] User chose to stop execution due to integrity test failure for '{version_name}'"
-                    )
 
         except Exception as e:
             notification_manager.error(

--- a/src/batch_tamarin/utils/model_checking.py
+++ b/src/batch_tamarin/utils/model_checking.py
@@ -60,20 +60,18 @@ async def validate_with_tamarin(
             errors = parse_tamarin_output(result.stdout, report, task)
 
             if errors or result.returncode != 0:
-                validation_errors[task.tamarin_version_name] = errors
+                validation_errors[task.task_name] = errors
                 if result.returncode != 0 and not errors:
-                    validation_errors[task.tamarin_version_name] = [
+                    validation_errors[task.task_name] = [
                         f"Non-zero exit code: {result.returncode}"
                     ]
 
         except subprocess.TimeoutExpired:
-            validation_errors[task.tamarin_version_name] = [
+            validation_errors[task.task_name] = [
                 "Validation timed out after 60 seconds"
             ]
         except Exception as e:
-            validation_errors[task.tamarin_version_name] = [
-                f"Validation failed: {str(e)}"
-            ]
+            validation_errors[task.task_name] = [f"Validation failed: {str(e)}"]
 
     return validation_errors
 

--- a/src/batch_tamarin/utils/model_checking.py
+++ b/src/batch_tamarin/utils/model_checking.py
@@ -1,0 +1,105 @@
+"""
+Model checking utilities for Tamarin validation.
+
+This module provides functionality to validate theory files with tamarin executables
+without running full proofs, to check for warnings and errors.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List
+
+from .notifications import notification_manager
+
+if TYPE_CHECKING:
+    from ..model.executable_task import ExecutableTask
+
+
+async def validate_with_tamarin(
+    executable_tasks: List["ExecutableTask"],
+) -> Dict[str, List[str]]:
+    """
+    Validate theory files with tamarin executables.
+
+    Runs tamarin without --prove flags to check for warnings/errors in theory files.
+    Groups tasks by unique (tamarin_executable, theory_file) combinations to avoid
+    duplicate validation runs.
+
+    Args:
+        executable_tasks: List of ExecutableTask objects to validate
+
+    Returns:
+        Dict mapping tamarin version names to lists of error/warning messages
+    """
+    validation_errors: Dict[str, List[str]] = {}
+
+    # Group tasks by unique (tamarin_executable, theory_file) combinations
+    unique_validations: Dict[tuple[str, str], "ExecutableTask"] = {}
+    for task in executable_tasks:
+        key = (str(task.tamarin_executable), str(task.theory_file))
+        if key not in unique_validations:
+            unique_validations[key] = task
+
+    for (_, _), task in unique_validations.items():
+        try:
+            # Run tamarin without any prove flags to check for warnings/errors
+            cmd = [str(task.tamarin_executable), str(task.theory_file)]
+
+            notification_manager.debug(f"Running validation: {' '.join(cmd)}")
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,  # 1 minute timeout for validation
+                cwd=Path.cwd(),
+            )
+
+            # Parse output for warnings and errors
+            errors = parse_tamarin_output(result.stdout + result.stderr)
+
+            if errors or result.returncode != 0:
+                validation_errors[task.tamarin_version_name] = errors
+                if result.returncode != 0 and not errors:
+                    validation_errors[task.tamarin_version_name] = [
+                        f"Non-zero exit code: {result.returncode}"
+                    ]
+
+        except subprocess.TimeoutExpired:
+            validation_errors[task.tamarin_version_name] = [
+                "Validation timed out after 60 seconds"
+            ]
+        except Exception as e:
+            validation_errors[task.tamarin_version_name] = [
+                f"Validation failed: {str(e)}"
+            ]
+
+    return validation_errors
+
+
+def parse_tamarin_output(output: str) -> List[str]:
+    """
+    Parse tamarin output to extract warnings and errors.
+
+    Args:
+        output: Combined stdout and stderr from tamarin execution
+
+    Returns:
+        List of error/warning messages found in the output
+    """
+    errors: list[str] = []
+
+    for line in output.split("\n"):
+        line = line.strip()
+        if line and any(
+            keyword in line.lower()
+            for keyword in ["warning", "error", "fail", "abort", "exception"]
+        ):
+            # Filter out some common non-error messages
+            if not any(
+                ignore in line.lower()
+                for ignore in ["no warning", "warning: none", "successfully"]
+            ):
+                errors.append(line)
+
+    return errors

--- a/src/batch_tamarin/utils/notifications.py
+++ b/src/batch_tamarin/utils/notifications.py
@@ -561,9 +561,9 @@ class NotificationManager:
             error_components: list[Markdown] = []
             for version, errors in tamarin_errors.items():
                 if errors:
-                    error_components.append(Markdown(f"**⚠️ {version}:**"))
+                    error_components.append(Markdown(f"**- ⚠️ Task :** *{version}*"))
                     for error in errors:
-                        error_components.append(Markdown(f"  • {error}"))
+                        error_components.append(Markdown(f"{error}"))
 
             if error_components:
                 components.append(

--- a/src/batch_tamarin/utils/notifications.py
+++ b/src/batch_tamarin/utils/notifications.py
@@ -513,6 +513,18 @@ class NotificationManager:
                 timeout_display,
             )
 
+        # Tamarin path panel
+        tamarin_path: list[Markdown] = []
+        binary_count = len(recipe.tamarin_versions)
+        header_text = (
+            "**📂 Tamarin binary path :**"
+            if binary_count == 1
+            else "**📂 Tamarin binaries paths :**"
+        )
+        tamarin_path.append(Markdown(header_text))
+        for alias, version in recipe.tamarin_versions.items():
+            tamarin_path.append(Markdown(f"**- Alias : '{alias}'** → {version.path}"))
+
         # Version breakdown table
         version_table = Table(show_header=True, header_style="bold yellow")
         version_table.add_column("Alias", style="yellow")
@@ -552,6 +564,7 @@ class NotificationManager:
         task_panel = Panel(details_table, title="Task Details", border_style="blue")
 
         components: List[Any] = [
+            Group(*tamarin_path),
             overview_panel,
             task_panel,
         ]

--- a/src/batch_tamarin/utils/system_resources.py
+++ b/src/batch_tamarin/utils/system_resources.py
@@ -6,6 +6,8 @@ that can be used when "max" is specified in configuration files.
 """
 
 import os
+import shutil
+from pathlib import Path
 
 import psutil
 
@@ -94,3 +96,34 @@ def get_system_info() -> dict[str, int]:
         - 'max_memory_gb': Maximum memory in GB available
     """
     return {"max_cores": get_max_cpu_cores(), "max_memory_gb": get_max_memory_gb()}
+
+
+def resolve_executable_path(path_or_command: str) -> Path:
+    """
+    Resolve an executable path, handling both file paths and bare commands.
+
+    Args:
+        path_or_command: Either a file path (absolute/relative) or a command name
+
+    Returns:
+        Resolved Path object to the executable
+
+    Raises:
+        FileNotFoundError: If the path/command cannot be resolved
+        ValueError: If the resolved path is not a file
+    """
+    # If it looks like a path (contains / or \), treat it as a file path
+    if "/" in path_or_command or "\\" in path_or_command:
+        resolved_path = Path(path_or_command)
+        if not resolved_path.exists():
+            raise FileNotFoundError(f"Executable file not found: {resolved_path}")
+        if not resolved_path.is_file():
+            raise ValueError(f"Path is not a file: {resolved_path}")
+        return resolved_path
+
+    # Otherwise, try to resolve as a command in PATH
+    resolved_command = shutil.which(path_or_command)
+    if resolved_command is None:
+        raise FileNotFoundError(f"Command '{path_or_command}' not found in PATH")
+
+    return Path(resolved_command)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ the batch-tamarin package, including mock data and helper utilities.
 import json
 import tempfile
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, Generator, List, Tuple
+from typing import Any, Callable, Dict, Generator, List, Tuple
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -193,23 +193,6 @@ def mock_notifications(monkeypatch: MonkeyPatch):
         "batch_tamarin.modules.config_manager.notification_manager", mock_manager
     )
     return mock_manager
-
-
-@pytest.fixture
-def mock_tamarin_integrity_check(
-    monkeypatch: MonkeyPatch,
-) -> Callable[[Dict[str, Any]], Awaitable[None]]:
-    """Mock the tamarin integrity check to avoid actual tamarin execution."""
-
-    async def mock_check(tamarin_versions: Dict[str, Any]) -> None:
-        """Mock integrity check that always passes."""
-        # Mock check function - tamarin_versions parameter is required by interface
-        _ = tamarin_versions  # Mark as used to avoid lint warning
-
-    monkeypatch.setattr(
-        "batch_tamarin.modules.config_manager.check_tamarin_integrity", mock_check
-    )
-    return mock_check
 
 
 @pytest.fixture

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -24,7 +24,6 @@ class TestJSONLoading:
         minimal_recipe_data: Dict[str, Any],
         create_json_file: Callable[[Dict[str, Any]], Path],
         mock_notifications: Any,
-        mock_tamarin_integrity_check: Any,
     ):
         """Test loading a valid JSON recipe."""
         config_file = create_json_file(minimal_recipe_data)
@@ -42,29 +41,6 @@ class TestJSONLoading:
             msg for level, msg in mock_notifications.messages if level == "success"
         ]
         assert any("JSON recipe loaded" in msg for msg in success_messages)
-
-    @pytest.mark.asyncio
-    async def test_load_json_with_revalidation(
-        self,
-        minimal_recipe_data: Dict[str, Any],
-        create_json_file: Callable[[Dict[str, Any]], Path],
-        mock_notifications: Any,
-        mock_tamarin_integrity_check: Any,
-    ):
-        """Test loading JSON with revalidation enabled."""
-        config_file = create_json_file(minimal_recipe_data)
-
-        recipe = await ConfigManager.load_json_recipe(config_file, revalidate=True)
-
-        assert isinstance(recipe, TamarinRecipe)
-
-        # Verify phase separator was called for integrity testing
-        phase_messages = [
-            msg
-            for level, msg in mock_notifications.messages
-            if level == "phase_separator"
-        ]
-        assert any("Tamarin Integrity Testing" in msg for msg in phase_messages)
 
     @pytest.mark.asyncio
     async def test_load_nonexistent_file(self, tmp_dir: Path, mock_notifications: Any):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,7 +19,6 @@ async def test_minimal_recipe_end_to_end(
     minimal_recipe_data: Dict[str, Any],
     create_json_file: Callable[..., Path],
     mock_notifications: Any,
-    mock_tamarin_integrity_check: Any,
     setup_output_manager: Any,
 ) -> None:
     """Test complete workflow with minimal recipe configuration."""
@@ -73,7 +72,6 @@ async def test_complex_recipe_end_to_end(
     complex_recipe_data: Dict[str, Any],
     create_json_file: Callable[..., Path],
     mock_notifications: Any,
-    mock_tamarin_integrity_check: Any,
     setup_output_manager: Any,
 ) -> None:
     """Test complete workflow with complex recipe configuration."""
@@ -138,7 +136,6 @@ async def test_resource_inheritance_and_capping(
     complex_recipe_data: Dict[str, Any],
     create_json_file: Callable[..., Path],
     mock_notifications: Any,
-    mock_tamarin_integrity_check: Any,
     setup_output_manager: Any,
 ) -> None:
     """Test that resource inheritance and global capping work correctly."""
@@ -189,7 +186,6 @@ async def test_unique_task_id_generation(
     minimal_recipe_data: Dict[str, Any],
     create_json_file: Callable[..., Path],
     mock_notifications: Any,
-    mock_tamarin_integrity_check: Any,
     setup_output_manager: Any,
 ) -> None:
     """Test that task IDs are unique when there are duplicates."""
@@ -222,7 +218,6 @@ async def test_lemma_prefix_matching(
     complex_recipe_data: Dict[str, Any],
     create_json_file: Callable[..., Path],
     mock_notifications: Any,
-    mock_tamarin_integrity_check: Any,
     setup_output_manager: Any,
 ) -> None:
     """Test that lemma prefix matching works correctly."""


### PR DESCRIPTION
# New features
- Rethinked CLI commands : `run` and `check`, moved revalidate flag to check
- Path specified in the JSON for tamarin prover could be defined as `tamarin-prover` and will use the system installed Tamarin prover.
- Wellformedness warnings can be obtained with the new `check` command