### PR TITLE
Fix: digit at first position in task names

### DIFF
--- a/src/batch_tamarin/model/tamarin_recipe.py
+++ b/src/batch_tamarin/model/tamarin_recipe.py
@@ -8,7 +8,7 @@ the tamarin-config-schema.json specification.
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SchedulingStrategy(str, Enum):
@@ -196,26 +196,3 @@ class TamarinRecipe(BaseModel):
     tasks: Dict[str, Task] = Field(
         ..., description="Named tasks, each defining a Tamarin execution configuration"
     )
-
-    @model_validator(mode="after")
-    def validate_name_patterns(self) -> "TamarinRecipe":
-        """Validate that keys match the required pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$"""
-        import re
-
-        pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
-
-        # Validate tamarin_versions keys
-        for key in self.tamarin_versions.keys():
-            if not pattern.match(key):
-                raise ValueError(
-                    f'Tamarin version key "{key}" must start with a letter and contain only letters, numbers, underscores, and hyphens'
-                )
-
-        # Validate tasks keys
-        for key in self.tasks.keys():
-            if not pattern.match(key):
-                raise ValueError(
-                    f'Task key "{key}" must start with a letter and contain only letters, numbers, underscores, and hyphens'
-                )
-
-        return self

--- a/tamarin-config-schema.json
+++ b/tamarin-config-schema.json
@@ -57,37 +57,33 @@
     "tamarin_versions": {
       "type": "object",
       "description": "Named aliases for different Tamarin prover executables",
-      "patternProperties": {
-        "^[a-zA-Z][a-zA-Z0-9_-]*$": {
-          "type": "object",
-          "required": ["path"],
-          "properties": {
-            "path": {
-              "type": "string",
-              "description": "File path to the Tamarin prover executable"
-            },
-            "version": {
-              "type": "string",
-              "description": "Version identifier for this Tamarin prover"
-            },
-            "test_success": {
-              "type": "boolean",
-              "description": "Whether this Tamarin executable passed connectivity tests"
-            }
+      "additionalProperties": {
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "File path to the Tamarin prover executable"
           },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
+          "version": {
+            "type": "string",
+            "description": "Version identifier for this Tamarin prover"
+          },
+          "test_success": {
+            "type": "boolean",
+            "description": "Whether this Tamarin executable passed connectivity tests"
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "tasks": {
       "type": "object",
       "description": "Named tasks, each defining a Tamarin execution configuration",
-      "patternProperties": {
-        "^[a-zA-Z][a-zA-Z0-9_-]*$": {
-          "type": "object",
-          "required": ["theory_file", "tamarin_versions", "output_file_prefix"],
-          "properties": {
+      "additionalProperties": {
+        "type": "object",
+        "required": ["theory_file", "tamarin_versions", "output_file_prefix"],
+        "properties": {
 				"theory_file": {
 					"type": "string",
 					"description": "Path to the .spthy theory file to analyze"
@@ -204,8 +200,7 @@
 			},
           "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
close #36 

This PR introduce a fix when there is a digit in the task name.
It modifies the models to have a lighter task name verification.