### PR TITLE
Filter tasks by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ batch-tamarin run recipe.json
 # Run with debug output
 batch-tamarin run recipe.json --debug
 
+# Run only tasks whose generated unique task ID starts with a prefix
+batch-tamarin run recipe.json --task <prefix>
+
 # Check configuration and preview tasks
 batch-tamarin check recipe.json
 
@@ -118,6 +121,8 @@ batch-tamarin report ./results --output report.tex --format tex
 # Clear cached results
 batch-tamarin --rm-cache
 ```
+
+The `--task`/`-t` option of `run` filters tasks by prefix on their generated unique task name (`{output_file_prefix}--{lemma_name}--{tamarin_version}`). Use `batch-tamarin check recipe.json` to preview the generated task names.
 
 ### Configuration Example
 

--- a/src/batch_tamarin/commands/run.py
+++ b/src/batch_tamarin/commands/run.py
@@ -15,7 +15,7 @@ from ..utils.notifications import notification_manager
 
 
 async def process_config_file(
-    config_path: Path, scheduler: SchedulingStrategy = SchedulingStrategy.FIFO
+    config_path: Path, scheduler: SchedulingStrategy = SchedulingStrategy.FIFO, task_name: str | None = None,
 ) -> None:
     """Process configuration file and execute tasks using unified direct path."""
     try:
@@ -28,7 +28,10 @@ async def process_config_file(
 
         # Convert recipe to executable tasks directly (unified path like check.py)
         executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
-
+        
+        if task_name:
+            executable_tasks = [task for task in executable_tasks if task.task_name.startswith(task_name)]
+        
         # Execute tasks using the direct execution path
         await runner.execute_all_tasks(executable_tasks)
 
@@ -49,6 +52,7 @@ class RunCommand:
         config_file: str,
         debug: bool = False,
         scheduler: SchedulingStrategy = SchedulingStrategy.FIFO,
+        task_name: str | None = None,
     ) -> None:
         """
         Execute tasks from the specified configuration file.
@@ -57,6 +61,7 @@ class RunCommand:
             config_file: Path to JSON recipe file to execute
             debug: Enable debug output
             scheduler: Task scheduling strategy
+            task_name: Taks name if specific task should be executed
         """
         # Set debug mode if enabled
         if debug:
@@ -66,7 +71,7 @@ class RunCommand:
         # Execute config file tasks
         config_path = Path(config_file)
         try:
-            asyncio.run(process_config_file(config_path, scheduler))
+            asyncio.run(process_config_file(config_path, scheduler, task_name))
         except Exception as e:
             notification_manager.error(f"Failed to process JSON recipe : {e}")
             raise

--- a/src/batch_tamarin/commands/run.py
+++ b/src/batch_tamarin/commands/run.py
@@ -15,7 +15,9 @@ from ..utils.notifications import notification_manager
 
 
 async def process_config_file(
-    config_path: Path, scheduler: SchedulingStrategy = SchedulingStrategy.FIFO, task_name: str | None = None,
+    config_path: Path,
+    scheduler: SchedulingStrategy = SchedulingStrategy.FIFO,
+    task_name: str | None = None,
 ) -> None:
     """Process configuration file and execute tasks using unified direct path."""
     try:
@@ -28,10 +30,17 @@ async def process_config_file(
 
         # Convert recipe to executable tasks directly (unified path like check.py)
         executable_tasks = config_manager.recipe_to_executable_tasks(recipe)
-        
+
+        # Filter tasks by prefix on their generated unique task name.
+        # ExecutableTask.task_name has the form:
+        #   {output_file_prefix}--{lemma_name}--{tamarin_version}
         if task_name:
-            executable_tasks = [task for task in executable_tasks if task.task_name.startswith(task_name)]
-        
+            executable_tasks = [
+                task
+                for task in executable_tasks
+                if task.task_name.startswith(task_name)
+            ]
+
         # Execute tasks using the direct execution path
         await runner.execute_all_tasks(executable_tasks)
 
@@ -61,7 +70,7 @@ class RunCommand:
             config_file: Path to JSON recipe file to execute
             debug: Enable debug output
             scheduler: Task scheduling strategy
-            task_name: Taks name if specific task should be executed
+            task_name: Prefix of the generated unique task name to execute
         """
         # Set debug mode if enabled
         if debug:

--- a/src/batch_tamarin/main.py
+++ b/src/batch_tamarin/main.py
@@ -64,12 +64,13 @@ def run(
         "-s",
         help="Task scheduling strategy: fifo (file sequential scheduling), sjf (shortest job first), ljf (longest job first)",
     ),
+    task: str | None = typer.Option(None, "--task", "-t", help="Only execute specific task"),
 ) -> None:
     """
     Execute tasks from the specified configuration file.
     """
     try:
-        RunCommand.run(config_file, debug, scheduler)
+        RunCommand.run(config_file, debug, scheduler, task)
     except typer.Exit:
         # Re-raise typer.Exit to maintain proper exit codes
         raise

--- a/src/batch_tamarin/main.py
+++ b/src/batch_tamarin/main.py
@@ -64,7 +64,12 @@ def run(
         "-s",
         help="Task scheduling strategy: fifo (file sequential scheduling), sjf (shortest job first), ljf (longest job first)",
     ),
-    task: str | None = typer.Option(None, "--task", "-t", help="Only execute specific task"),
+    task: str | None = typer.Option(
+        None,
+        "--task",
+        "-t",
+        help="Only execute tasks who starts with this prefix",
+    ),
 ) -> None:
     """
     Execute tasks from the specified configuration file.

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -1,0 +1,198 @@
+"""
+Tests for the run command.
+
+This module tests task filtering and execution orchestration in the run command.
+External dependencies are mocked for CI compatibility.
+"""
+
+# pyright: basic
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from batch_tamarin.commands.run import process_config_file
+from batch_tamarin.model.executable_task import ExecutableTask
+from batch_tamarin.model.tamarin_recipe import TamarinRecipe
+
+
+@pytest.fixture
+def mock_executable_tasks() -> list[ExecutableTask]:
+    """Create mock executable tasks with predictable generated task names."""
+    return [
+        ExecutableTask(
+            task_name="alpha--lemma_a--stable",
+            original_task_name="alpha",
+            tamarin_version_name="stable",
+            tamarin_executable=Path("/mock/tamarin-prover"),
+            theory_file=Path("/mock/theory.spthy"),
+            output_file=Path("/mock/output1.txt"),
+            lemma="lemma_a",
+            tamarin_options=None,
+            preprocess_flags=None,
+            max_cores=2,
+            max_memory=4,
+            task_timeout=1800,
+            traces_dir=Path("/mock/traces"),
+        ),
+        ExecutableTask(
+            task_name="alpha--lemma_b--dev",
+            original_task_name="alpha",
+            tamarin_version_name="dev",
+            tamarin_executable=Path("/mock/tamarin-prover"),
+            theory_file=Path("/mock/theory.spthy"),
+            output_file=Path("/mock/output2.txt"),
+            lemma="lemma_b",
+            tamarin_options=None,
+            preprocess_flags=None,
+            max_cores=2,
+            max_memory=4,
+            task_timeout=1800,
+            traces_dir=Path("/mock/traces"),
+        ),
+        ExecutableTask(
+            task_name="beta--lemma_a--stable",
+            original_task_name="beta",
+            tamarin_version_name="stable",
+            tamarin_executable=Path("/mock/tamarin-prover"),
+            theory_file=Path("/mock/theory.spthy"),
+            output_file=Path("/mock/output3.txt"),
+            lemma="lemma_a",
+            tamarin_options=None,
+            preprocess_flags=None,
+            max_cores=2,
+            max_memory=4,
+            task_timeout=1800,
+            traces_dir=Path("/mock/traces"),
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_recipe() -> TamarinRecipe:
+    """Create a minimal mock recipe."""
+    return TamarinRecipe.model_validate(
+        {
+            "config": {
+                "global_max_cores": 8,
+                "global_max_memory": 16,
+                "default_timeout": 3600,
+                "output_directory": "./test-results",
+            },
+            "tamarin_versions": {
+                "stable": {"path": "/mock/tamarin-prover", "version": "1.10.0"}
+            },
+            "tasks": {
+                "alpha": {
+                    "theory_file": "/mock/theory.spthy",
+                    "tamarin_versions": ["stable"],
+                    "output_file_prefix": "alpha",
+                }
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_config_file_without_filter(
+    mock_recipe: TamarinRecipe,
+    mock_executable_tasks: list[ExecutableTask],
+    tmp_path: Path,
+) -> None:
+    """Test that all tasks are executed when no task prefix is provided."""
+    config_path = tmp_path / "recipe.json"
+    config_path.write_text("{}")
+
+    with patch("batch_tamarin.commands.run.ConfigManager") as mock_config_manager_cls:
+        config_manager = MagicMock()
+        config_manager.load_json_recipe = AsyncMock(return_value=mock_recipe)
+        config_manager.recipe_to_executable_tasks.return_value = mock_executable_tasks
+        mock_config_manager_cls.return_value = config_manager
+
+        with patch("batch_tamarin.commands.run.TaskRunner") as mock_runner_cls:
+            runner = MagicMock()
+            runner.execute_all_tasks = AsyncMock()
+            mock_runner_cls.return_value = runner
+
+            with patch(
+                "batch_tamarin.commands.run.BatchManager"
+            ) as mock_batch_manager_cls:
+                batch_manager = MagicMock()
+                batch_manager.generate_execution_report = AsyncMock()
+                mock_batch_manager_cls.return_value = batch_manager
+
+                await process_config_file(config_path)
+
+    runner.execute_all_tasks.assert_awaited_once()
+    executed_tasks = runner.execute_all_tasks.await_args[0][0]
+    assert len(executed_tasks) == 3
+
+
+@pytest.mark.asyncio
+async def test_process_config_file_with_prefix_filter(
+    mock_recipe: TamarinRecipe,
+    mock_executable_tasks: list[ExecutableTask],
+    tmp_path: Path,
+) -> None:
+    """Test that only tasks matching the prefix are executed."""
+    config_path = tmp_path / "recipe.json"
+    config_path.write_text("{}")
+
+    with patch("batch_tamarin.commands.run.ConfigManager") as mock_config_manager_cls:
+        config_manager = MagicMock()
+        config_manager.load_json_recipe = AsyncMock(return_value=mock_recipe)
+        config_manager.recipe_to_executable_tasks.return_value = mock_executable_tasks
+        mock_config_manager_cls.return_value = config_manager
+
+        with patch("batch_tamarin.commands.run.TaskRunner") as mock_runner_cls:
+            runner = MagicMock()
+            runner.execute_all_tasks = AsyncMock()
+            mock_runner_cls.return_value = runner
+
+            with patch(
+                "batch_tamarin.commands.run.BatchManager"
+            ) as mock_batch_manager_cls:
+                batch_manager = MagicMock()
+                batch_manager.generate_execution_report = AsyncMock()
+                mock_batch_manager_cls.return_value = batch_manager
+
+                await process_config_file(config_path, task_name="alpha")
+
+    executed_tasks = runner.execute_all_tasks.await_args[0][0]
+    assert len(executed_tasks) == 2
+    assert all(task.task_name.startswith("alpha") for task in executed_tasks)
+
+
+@pytest.mark.asyncio
+async def test_process_config_file_with_no_matching_prefix(
+    mock_recipe: TamarinRecipe,
+    mock_executable_tasks: list[ExecutableTask],
+    tmp_path: Path,
+) -> None:
+    """Test that an unmatched prefix results in an empty task list."""
+    config_path = tmp_path / "recipe.json"
+    config_path.write_text("{}")
+
+    with patch("batch_tamarin.commands.run.ConfigManager") as mock_config_manager_cls:
+        config_manager = MagicMock()
+        config_manager.load_json_recipe = AsyncMock(return_value=mock_recipe)
+        config_manager.recipe_to_executable_tasks.return_value = mock_executable_tasks
+        mock_config_manager_cls.return_value = config_manager
+
+        with patch("batch_tamarin.commands.run.TaskRunner") as mock_runner_cls:
+            runner = MagicMock()
+            runner.execute_all_tasks = AsyncMock()
+            mock_runner_cls.return_value = runner
+
+            with patch(
+                "batch_tamarin.commands.run.BatchManager"
+            ) as mock_batch_manager_cls:
+                batch_manager = MagicMock()
+                batch_manager.generate_execution_report = AsyncMock()
+                mock_batch_manager_cls.return_value = batch_manager
+
+                await process_config_file(config_path, task_name="gamma")
+
+    executed_tasks = runner.execute_all_tasks.await_args[0][0]
+    assert len(executed_tasks) == 0


### PR DESCRIPTION
Hey @lmandrelli,

When running a recipe, I sometimes find it helpful not to execute all tasks every time. To address this, I added a simple option to the run command that allows filtering tasks by name prefix. I’d love to hear your thoughts.