### PR TITLE
Add prune function and size check for cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ batch-tamarin report ./results --output report.html --format html
 # Generate LaTeX report for academic publications
 batch-tamarin report ./results --output report.tex --format tex
 
-# Clear cached results
-batch-tamarin --rm-cache
+# Clear cached results (keeps the cache directory structure intact)
+batch-tamarin cache clear
+
+# Completely remove the cache directory, bypassing diskcache validation
+batch-tamarin cache prune
 ```
 
 The `--task`/`-t` option of `run` filters tasks by prefix on their generated unique task name (`{output_file_prefix}--{lemma_name}--{tamarin_version}`). Use `batch-tamarin check recipe.json` to preview the generated task names.

--- a/src/batch_tamarin/commands/cache.py
+++ b/src/batch_tamarin/commands/cache.py
@@ -4,6 +4,8 @@ Cache command for batch-tamarin.
 This module handles cache interaction commands.
 """
 
+import shutil
+
 import typer
 
 from ..modules.cache_manager import CacheManager
@@ -25,6 +27,13 @@ def clear(
     """
 
     CacheCommand.clear(errors_only=errors_only)
+
+
+@cache_command.command()
+def prune() -> None:
+    """Prunes the cache, removing everything without validation."""
+
+    CacheCommand.prune()
 
 
 class CacheCommand:
@@ -50,6 +59,16 @@ class CacheCommand:
             )
 
             print(f"Cleared cache: {entries} entries, {volume}")
+        except Exception as e:
+            print(f"Failed to clear cache: {e}")
+            raise typer.Exit(1)
+
+    @staticmethod
+    def prune() -> None:
+        try:
+            path = CacheManager.get_cache_dir()
+            shutil.rmtree(path)
+            print(f"Pruned cache!")
         except Exception as e:
             print(f"Failed to clear cache: {e}")
             raise typer.Exit(1)

--- a/src/batch_tamarin/commands/cache.py
+++ b/src/batch_tamarin/commands/cache.py
@@ -68,7 +68,9 @@ class CacheCommand:
         try:
             path = CacheManager.get_cache_dir()
             shutil.rmtree(path)
-            print(f"Pruned cache!")
+            print("Pruned cache!")
+        except FileNotFoundError:
+            print("Cache directory does not exist, nothing to prune.")
         except Exception as e:
-            print(f"Failed to clear cache: {e}")
+            print(f"Failed to prune cache: {e}")
             raise typer.Exit(1)

--- a/src/batch_tamarin/modules/cache_manager.py
+++ b/src/batch_tamarin/modules/cache_manager.py
@@ -9,11 +9,12 @@ unique cache keys.
 import hashlib
 from pathlib import Path
 
-from diskcache import Cache
 import typer
+from diskcache import Cache
 
 from ..model.executable_task import ExecutableTask, TaskResult, TaskStatus
 from ..utils.notifications import notification_manager
+from ..utils.system_resources import get_human_readable_volume_size
 
 
 class CachedTaskData:
@@ -34,20 +35,44 @@ class CachedTaskData:
 class CacheManager:
     """Manages persistent caching of Tamarin task results."""
 
+    CACHE_SIZE_LIMIT: int = int(2e9)  # 2GB limit
+
     @staticmethod
     def get_cache_dir() -> Path:
         return Path.home() / ".batch-tamarin" / "cache"
 
+    @staticmethod
+    def _get_directory_size(path: Path) -> int:
+        """Recursively calculate the total size of all files in a directory.
+
+        Args:
+            path: Directory to measure
+
+        Returns:
+            Total size in bytes of all regular files under the directory
+        """
+        return sum(file.stat().st_size for file in path.rglob("*") if file.is_file())
+
     def __init__(self) -> None:
         """Initialize cache manager with user-specific cache directory."""
 
-        limit: int = int(2e9)
         cache_dir = self.get_cache_dir()
-        if cache_dir.exists() and cache_dir.stat().st_size > limit:
-            print(f"The maximum cache size has been exceeded, use `cache prune` to clear it!")
-            typer.Exit(1)
+        if (
+            cache_dir.exists()
+            and self._get_directory_size(cache_dir) > self.CACHE_SIZE_LIMIT
+        ):
+            current_size = get_human_readable_volume_size(
+                self._get_directory_size(cache_dir)
+            )
+            limit_size = get_human_readable_volume_size(self.CACHE_SIZE_LIMIT)
+            print(
+                f"The maximum cache size has been exceeded "
+                f"({current_size} / {limit_size}), "
+                f"use `batch-tamarin cache prune` to clear it!"
+            )
+            raise typer.Exit(1)
 
-        self.cache: Cache = Cache(str(cache_dir), size_limit=limit)  # 2GB limit
+        self.cache: Cache = Cache(str(cache_dir), size_limit=self.CACHE_SIZE_LIMIT)
 
     def get_cached_result(self, task: ExecutableTask) -> TaskResult | None:
         """

--- a/src/batch_tamarin/modules/cache_manager.py
+++ b/src/batch_tamarin/modules/cache_manager.py
@@ -10,6 +10,7 @@ import hashlib
 from pathlib import Path
 
 from diskcache import Cache
+import typer
 
 from ..model.executable_task import ExecutableTask, TaskResult, TaskStatus
 from ..utils.notifications import notification_manager
@@ -33,10 +34,20 @@ class CachedTaskData:
 class CacheManager:
     """Manages persistent caching of Tamarin task results."""
 
+    @staticmethod
+    def get_cache_dir() -> Path:
+        return Path.home() / ".batch-tamarin" / "cache"
+
     def __init__(self) -> None:
         """Initialize cache manager with user-specific cache directory."""
-        cache_dir = Path.home() / ".batch-tamarin" / "cache"
-        self.cache: Cache = Cache(str(cache_dir), size_limit=int(2e9))  # 2GB limit
+
+        limit: int = int(2e9)
+        cache_dir = self.get_cache_dir()
+        if cache_dir.exists() and cache_dir.stat().st_size > limit:
+            print(f"The maximum cache size has been exceeded, use `cache prune` to clear it!")
+            typer.Exit(1)
+
+        self.cache: Cache = Cache(str(cache_dir), size_limit=limit)  # 2GB limit
 
     def get_cached_result(self, task: ExecutableTask) -> TaskResult | None:
         """

--- a/tests/test_cache_command.py
+++ b/tests/test_cache_command.py
@@ -1,0 +1,64 @@
+"""
+Tests for the cache command module.
+
+This module tests the CLI-facing CacheCommand helpers, including the
+prune operation that removes the cache directory without instantiating
+diskcache.
+"""
+
+# pyright: basic
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+from _pytest.monkeypatch import MonkeyPatch
+
+from batch_tamarin.commands.cache import CacheCommand
+
+
+class TestCacheCommand:
+    """Test cases for the cache command helpers."""
+
+    def test_prune_removes_cache_directory(
+        self, tmp_dir: Path, monkeypatch: MonkeyPatch
+    ):
+        """Test that prune deletes the cache directory."""
+        cache_dir = tmp_dir / ".batch-tamarin" / "cache"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "entry.bin").write_bytes(b"cached data")
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_dir)
+
+        CacheCommand.prune()
+
+        assert not cache_dir.exists()
+
+    def test_prune_is_idempotent_for_missing_directory(
+        self, tmp_dir: Path, monkeypatch: MonkeyPatch
+    ):
+        """Test that prune succeeds when the cache directory is already gone."""
+        cache_dir = tmp_dir / ".batch-tamarin" / "cache"
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_dir)
+
+        CacheCommand.prune()
+
+        assert not cache_dir.exists()
+
+    def test_prune_reports_failure(self, tmp_dir: Path, monkeypatch: MonkeyPatch):
+        """Test that prune exits with an error when deletion fails."""
+        cache_dir = tmp_dir / ".batch-tamarin" / "cache"
+        cache_dir.mkdir(parents=True)
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_dir)
+
+        with patch(
+            "batch_tamarin.commands.cache.shutil.rmtree",
+            side_effect=PermissionError("permission denied"),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                CacheCommand.prune()
+
+        assert exc_info.value.exit_code == 1

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+import typer
 from _pytest.monkeypatch import MonkeyPatch
 
 from batch_tamarin.model.executable_task import ExecutableTask, TaskResult, TaskStatus
@@ -502,3 +503,33 @@ class TestCacheManager:
         # Check that cache directory is created under user home
         expected_path = Path.home() / ".batch-tamarin" / "cache"
         assert Path(cache_manager.cache.directory) == expected_path
+
+    def test_cache_manager_refuses_to_open_oversized_cache(
+        self, tmp_dir: Path, monkeypatch: MonkeyPatch
+    ):
+        """Test that CacheManager exits when the cache directory exceeds the size limit."""
+        cache_dir = tmp_dir / ".batch-tamarin" / "cache"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "big.bin").write_bytes(b"x" * 1000)
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_dir)
+        monkeypatch.setattr(CacheManager, "CACHE_SIZE_LIMIT", 500)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            CacheManager()
+
+        assert exc_info.value.exit_code == 1
+
+    def test_cache_manager_opens_cache_below_size_limit(
+        self, tmp_dir: Path, monkeypatch: MonkeyPatch
+    ):
+        """Test that CacheManager initializes normally when the cache is below the limit."""
+        cache_dir = tmp_dir / ".batch-tamarin" / "cache"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "small.bin").write_bytes(b"x" * 100)
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_dir)
+        monkeypatch.setattr(CacheManager, "CACHE_SIZE_LIMIT", 500)
+
+        cache_manager = CacheManager()
+        assert cache_manager.cache is not None


### PR DESCRIPTION
Hi @lmandrelli,

I've noticed that, once the cache size limit has been reached, `batch-tamarin` cannot be used anymore because instantiating the `diskcache.Cache` object raises an error. Therefore, I perform a size check before doing so. I've also added a 'prune' command, which allows the cache directory to be deleted without first instantiating the `diskcache.Cache` object.

Let me know what you think. 